### PR TITLE
refactor compute_relative_time

### DIFF
--- a/code/libs/reltime.py
+++ b/code/libs/reltime.py
@@ -2,50 +2,38 @@
 
 import time
 
+from code.libs.text import plural
+
+
 def compute_relative_time(timestamp=1340875790):
     #git/data.c void show_date_relative
     delta = int(time.time()) - int(timestamp)
-    # In unitests we have 0 or 1 seconds, not stable, better say 'few' when below 10 s.
+    # In unitests we have 0 or 1 seconds, not stable,
+    # better say 'few' when below 10 s.
     if delta < 10:
         return "few seconds ago"
     if delta < 90:
         return str(delta) + " seconds ago"
-    #Turn it into minutes
-    delta = (delta + 30) / 60
-    if delta < 90:
-        return str(delta) + " minutes ago"
-    #Turn it into hours
-    delta = (delta + 30) / 60
-    if delta < 36:
-        return str(delta) + " hours ago"
-    #We deal with number of days from here on
-    delta = (delta + 12) / 24
-    if delta < 14:
-        return str(delta) + " days ago"
-    #Say weeks for the past 10 weeks or so
-    if delta < 70:
-        return str((delta + 3) / 7) + " weeks ago"
-    #Say months for the past 12 months or so
-    if delta < 365:
-        return str((delta + 15) / 30) + " months ago"
-    #Give years and months for 5 years or so */
-    if delta < 1825:
-        totalmonths = (delta * 12 * 2 + 365) / (365 * 2)
-        years = totalmonths / 12
-        months = totalmonths % 12
-        if years == 1:
-            if months > 1:
-                return "1 year, %s months ago" % months
-            elif months == 1:
-                return "1 year, 1 month ago"
-            else:
-                return "1 year ago"
-        else:
-            if months == 1:
-                return "%s years, 1 month ago" % years
-            elif months:
-                return "%s years, %s months ago" % (years, months)
-            else:
-                return str(years) + " years ago"
-    #Otherwise, just years
-    return str((delta + 183) / 365) + " years ago"
+
+    chunks = (
+        (60 * 60 * 24 * 365, lambda n: plural(n, 'year', 'years')),
+        (60 * 60 * 24 * 30, lambda n: plural(n, 'month', 'months')),
+        (60 * 60 * 24 * 7, lambda n: plural(n, 'week', 'weeks')),
+        (60 * 60 * 24, lambda n: plural(n, 'day', 'days')),
+        (60 * 60, lambda n: plural(n, 'hour', 'hours')),
+        (60, lambda n: plural(n, 'minute', 'minutes'))
+    )
+
+    for i, (seconds, name) in enumerate(chunks):
+        count = delta // seconds
+        if count != 0:
+            break
+
+    s = '{0} {1}'.format(count, name(count))
+
+    if i + 1 < len(chunks):
+        seconds2, name2 = chunks[i + 1]
+        count2 = (delta - (seconds * count)) // seconds2
+        if count2 != 0:
+            s += ' {0} {1}'.format(count2, name2(count2))
+    return s + ' ago'


### PR DESCRIPTION
我读code源码, 发现格式化的相对时间, 代码看起来,怪怪的, 都是根据经验做的hack, 我参照了django的[源码](https://github.com/django/django/blob/master/django/utils/timesince.py)

我修改后有些问题:
1. 有一些情况没有考虑，结果太硬性,比如10天前,我会记为: `1 week 3 days ago` 而不是 `10 days ago`
