### PR TITLE
Fixed:

### DIFF
--- a/quick_start.sh
+++ b/quick_start.sh
@@ -1,18 +1,27 @@
-#!/bin/sh
+#!/bin/bash
 
 echo "Setup database..."
 . ./setup_databases.sh
 
 echo "Init virtualenv..."
+which virtualenv > /dev/null 2>&1
+if [ $? != 0 ];then
+    echo "Install virtualenv..."
+    pip install virtualenv
+fi
 virtualenv venv
 . venv/bin/activate
 pip install -U setuptools
 pip install cython
+
+which mysql_config > /dev/null 2>&1
+if [ $? != 0 ];then
+    echo "mysql_config: command not found, must install it!"
+    exit 1
+fi
 pip install -r requirements.txt
 
 echo "Start serveing!!!"
 echo
 echo
-deactivate
-. venv/bin/activate
 gunicorn -w 2 -b 0.0.0.0:8000 app:app

--- a/setup_databases.sh
+++ b/setup_databases.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
-
-echo "drop database if exists valentine" | mysql
-echo "create database valentine" | mysql
-if [ $? -ne 0 ]; then
-    echo "create database valentine" | mysql -uroot -p
+read -p "Please input Mysql User(default is root):" user
+if [ "${user}" = "" ];then
+    user="root"
 fi
-(echo "use valentine"; cat code/databases/schema.sql) | mysql
+read -p "Please input Mysql ${user}'s password(default is ''):" passwd
+echo "drop database if exists valentine" | mysql --user=${user} --password=${passwd}
+echo "create database valentine" | mysql --user=${user} --password=${passwd}
+if [ $? -ne 0 ]; then
+    echo "create database valentine" | mysql --user=${user} --password=${passwd}
+fi
+(echo "use valentine"; cat code/databases/schema.sql) | mysql --user=${user} --password=${passwd}


### PR DESCRIPTION
1. When mysql_config not installed
2. When virtualenv not installed
3. Bugfix: Setup database Access denied

使用 setup_databases.sh确实更块的设置mysql,但是使用command|mysql 这样的方式本身有问题,因为没有指定账号密码,比如我这里报错:

```
Setup database...
ERROR 1044 (42000) at line 1: Access denied for user ''@'localhost' to database 'valentine'
ERROR 1044 (42000) at line 1: Access denied for user ''@'localhost' to database 'valentine'
```

我设计了一个提示输入账号密码的一步
