### PR TITLE
Bugfix:

### DIFF
--- a/vilya/views/__init__.py
+++ b/vilya/views/__init__.py
@@ -20,10 +20,11 @@ _q_exports = ['api',
 
 def _q_exception_handler(request, exception):
     if isinstance(exception, TraversalError):
-        error = exception
+        error = exception.title
+        current_user = request.user
         return st('/errors/404.html', **locals())
     if isinstance(exception, AccessError):
-        error = exception
+        error = exception.title
         return st('/errors/401.html', **locals())
     else:
         raise exception


### PR DESCRIPTION
1.  当出现某些原因造成错误没有正确生成git功能,应该是404没又找到,但是发现上面还是提示我需要登录，只是错误页面的处理没有设置`current_user`变量
2. Display error message is '???'  我看quixote源码, 他的异常类 比如TraversalError,没有定义__str__属性,在模板调用"${error}" 肯定是不能正常显示的, 我这里直接调用类里面的title属性.
