### PR TITLE
Feature for when signup validate email

### DIFF
--- a/vilya/config.py
+++ b/vilya/config.py
@@ -60,6 +60,8 @@ DOMAIN = "http://127.0.0.1:8000/"
 
 MAKO_FS_CHECK = True
 
+EMAIL_SUFFIX = 'douban.com'
+
 try:
     from local_config import *
 except ImportError:

--- a/vilya/libs/text.py
+++ b/vilya/libs/text.py
@@ -6,6 +6,8 @@ import hashlib
 from mikoto.libs.text import *
 from mikoto.libs.emoji import *
 
+from vilya.config import EMAIL_SUFFIX
+
 
 def trunc_utf8(string, num, etc="..."):
     """truncate a utf-8 string, show as num chars.
@@ -47,7 +49,7 @@ def email_normalizer(name, email):
     if _validate_email(email):
         return email
     else:
-        return name + '@douban.com'
+        return name + '@' + EMAIL_SUFFIX
 
 
 def is_image(fname):

--- a/vilya/templates/users/new.html
+++ b/vilya/templates/users/new.html
@@ -1,6 +1,11 @@
 <%inherit file="/layouts/base.html" />
 
 <%def name="title()">New user</%def>
+<%def name="make_value(attr)">
+% if attr:
+value=${attr}
+% endif
+</%def>
 
 <div class="hero-unit">
     <div class="panel panel-default">
@@ -12,25 +17,29 @@
                 <div class="form-group">
                     <label for="inputName" class="col-sm-2 control-label">Name</label>
                     <div class="col-sm-10">
-                        <input type="text" name="name" class="form-control" id="inputName" placeholder="Name">
+                        <input type="text" name="name" class="form-control" id="inputName" placeholder="Name" ${make_value(name)}>
                     </div>
                 </div>
                 <div class="form-group">
                     <label for="inputPassword" class="col-sm-2 control-label">Password</label>
                     <div class="col-sm-10">
-                        <input type="password" name="password" class="form-control" id="inputPassword" placeholder="">
+                        <input type="password" name="password" class="form-control" id="inputPassword" placeholder="" ${make_value(password)}>
                     </div>
                 </div>
+				% if not not_validate_email:
                 <div class="form-group">
+				% else:
+				<div class="form-group has-error">
+				% endif
                     <label for="inputEmail" class="col-sm-2 control-label">Email</label>
                     <div class="col-sm-10">
-                        <input type="text" name="email" class="form-control" id="inputEmail" placeholder="">
+                        <input type="text" name="email" class="form-control" id="inputEmail" placeholder="" ${make_value(email)}>
                     </div>
                 </div>
                 <div class="form-group">
                     <label for="inputDescription" class="col-sm-2 control-label">Description</label>
                     <div class="col-sm-10">
-                        <input type="text" name="description" class="form-control" id="inputDescription" placeholder="Description">
+                        <input type="text" name="description" class="form-control" id="inputDescription" placeholder="Description" ${make_value(description)}>
                     </div>
                 </div>
                 <div class="form-group">
@@ -43,4 +52,3 @@
         </div>
     </div>
 </div>
-

--- a/vilya/views/users/__init__.py
+++ b/vilya/views/users/__init__.py
@@ -6,6 +6,7 @@ from vilya.libs.template import st
 from vilya.models.project import Project
 from vilya.models.user import User
 from vilya.views.projects import ProjectUI
+from vilya.libs.text import _validate_email
 
 _q_exports = ['new']
 
@@ -21,6 +22,16 @@ def _q_index(request):
         password = request.get_form_var('password')
         email = request.get_form_var('email')
         description = request.get_form_var('description')
+
+        # Forced mail format must be correct
+        if not _validate_email(email):
+            context['name'] = name
+            context['not_validate_email'] = True
+            context['password'] = password
+            context['email'] = email
+            context['description'] = description
+            return st('users/new.html', **context)
+
         user = User.add(name=name,
                         password=password,
                         description=description,


### PR DESCRIPTION
今天给code添加了一个注册验证邮箱格式的功能

PS: 还有一个自定义公司邮箱后缀的功能

但是我发现不输入账号/密码都是可以注册的??

我本来想添加个邮箱格式不正确的错误提示, 但是css样式的input占满了整个div,实在加起来不好看,想了几个方案:
1. 添加到错误form的上面
2. 添加到panel上部
3. 鼠标悬浮显示到错误的input上
