### PR TITLE
fix bug: 仅当Python版本低于2.7时才会执行exit 1退出

### DIFF
--- a/scripts/install_code.sh
+++ b/scripts/install_code.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Check Python version > 2.7
-test `python -c 'import sys; print sys.version_info < (2, 7)'` = "True" && echo 'CODE requires Python 2.7.'; exit 1
+test `python -c 'import sys; print sys.version_info < (2, 7)'` = "True" && echo 'CODE requires Python 2.7.' && exit 1
 
 url='https://raw.github.com/douban/code/master/scripts'
 


### PR DESCRIPTION
原脚本不论Python版本是否低于2.7都会自动退出。
