### PR TITLE
Add virtualbox env

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ $boot2docker ip
 $docker run -t -i code /bin/bash
 ```
 
+Vagrant Installation
+--------------------
+
+```
+$cd code
+vagrant up
+```
+
 Quick Installation
 ------------------
 Currently supports the following systems:
@@ -58,47 +66,11 @@ bash <(curl -s https://raw.githubusercontent.com/douban/code/master/scripts/inst
 Notes: The install script in `code/scripts` subdirectory, for example ubuntu/debian,
 You can see `code/scripts/ubuntu.sh`
 
-Prepare
--------
-- mysql # default port
-
-```
-# import vilya/databases/schema.sql to database `valentine`
-$ mysql -uroot -e 'create database valentine;'
-$ mysql -uroot -D valentine < vilya/databases/schema.sql
-```
-
-- memcached # default port
-
-- customize code config
-```
-# after clone code repo you can change the default config by:
-$ cd {CODE_REPO}
-$ cp vilya/local_config.py.tmpl vilya/local_config.py
-# overwrite configs defined in vilya/config.py.
-$ vim vilya/local_config.py
-```
-
-Getting started
----------------
-```
-git clone https://github.com/douban/code.git
-cd code
-mysql -uroot -e 'create database valentine;'
-mysql -uroot -D valentine < vilya/databases/schema.sql
-virtualenv venv
-. venv/bin/activate
-pip install cython  # should install first
-pip install -U setuptools
-pip install -r requirements.txt
-gunicorn -w 2 -b 127.0.0.1:8000 app:app  # web & git http daemon
-```
-
 FAQ
 ----
 
 1. single http daemon
- - `gunicorn -b 127.0.0.1:8001 smart_httpd:app` # git http daemon
+ - `gunicorn -b 127.0.0.1:8001 app:app` # git http daemon
 
 2. vilya.config.DOMAIN
  - if you run 'gunicorn -b IP:PORT app:app', the DOMAIN should be 'http://IP:PORT/'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,10 @@
+# -*- mode: ruby -*-
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "dongweiming/code"
+
+  config.vm.network :forwarded_port, guest: 8200, host: 8200
+  for i in 29000..30000
+    config.vm.network :forwarded_port, guest: i, host: i
+  end
+end

--- a/scripts/ubuntu.sh
+++ b/scripts/ubuntu.sh
@@ -8,7 +8,7 @@ sudo apt-get install build-essential g++ git python-pip python-virtualenv dh-aut
 
 echo "Install mysql..."
 sudo apt-get install mysql-client mysql-server libmysqlclient-dev -yq
-/etc/init.d/mysql restart
+sudo /etc/init.d/mysql restart
 
 echo "Setup memcached port to 11311..."
 sudo sed -i "s/11211/11311/g" /etc/memcached.conf


### PR DESCRIPTION
喜大普奔

可以使用vagrant启动一个无痛开发环境了.

之前 @alemic @jumping @greatqn @kebot @aqqwiyth @GuoJing @lidashuang @liangshan 等同学说都抱怨过开发环境很痛苦.  以后这样的痛苦不再了~~~

现在可以直接

```python
$ cd code && vagrant up & vagrant ssh
# go http://localhost:8200/
```

我使用了 oh-my-zsh, [pure](https://github.com/sindresorhus/pure), supervisor, autoenv. 

直接登录环境, memcached, 数据库, CODE服务, 前端watch都是已经启动好了的. 对29000-30000和8200端口做了本地转发(我在supervisor里面启动code用的是8200). 

用户暂时还没有初始化. ipython, emacs编辑器的也没有装, 保证最小化的设置

可能需要:

```python
pip install ipython 
In [1]: from vilya.models.nuser import User2 as CodeUser
In [2]: u = CodeUser.add(name='test', password='test')  # 创建一个用户名和密码都是test的用户
Out[2]: <u 1, test>
In [3]: u.save()
Out[3]: 0

```

其次就是配置自己的源, 比如我:

```python
git remote rename origin upstream
git remote add origin https://github.com/dongweiming/code
```

然后经常pull代码:

```git pull --rebase upstream master```