### PR TITLE
add development server

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
+from argparse import ArgumentParser
 import re
 
+from werkzeug.serving import run_simple
 from web import app as web
 from app_sina import app as git_http
 
@@ -19,4 +21,28 @@ class Application(object):
                 return func(environ, start_response)
         return web(environ, start_response)
 
+    def run(self, host='127.0.0.1', port=8200, debug=False, **options):
+        options.setdefault('use_reloader', debug)
+        options.setdefault('use_debugger', debug)
+        run_simple(host, port, self, **options)
+
 app = Application()
+
+if __name__ == '__main__':
+    parser = ArgumentParser(description='run the development server')
+    parser.add_argument('--host', default='127.0.0.1',
+                        help='host(default: 127.0.0.1)')
+    parser.add_argument('--port', default=8200, type=int,
+                        help='port(default: 8200)')
+    parser.add_argument('-D', '--no-debug', action='store_true',
+                        help='disable the Werkzeug debugger')
+    parser.add_argument('-R', '--no-reload', action='store_true',
+                        help='do not monitor Python files for changes')
+    args = parser.parse_args()
+
+    host = args.host
+    port = args.port
+    use_debugger = not args.no_debug
+    use_reloader = not args.no_reload
+    app.run(host=host, port=port, use_debugger=use_debugger,
+            use_reloader=use_reloader)


### PR DESCRIPTION
```
$ python app.py --help
INFO:vilya.models.stubs:SearchClientStub.head is called
INFO:vilya.models.stubs:SearchClientStub.put is called
INFO:vilya.models.stubs:SearchClientStub.head is called
INFO:vilya.models.stubs:SearchClientStub.put is called
INFO:vilya.models.stubs:SearchClientStub.head is called
INFO:vilya.models.stubs:SearchClientStub.put is called
usage: app.py [-h] [--host HOST] [--port PORT] [-D] [-R]

run the development server

optional arguments:
  -h, --help       show this help message and exit
  --host HOST      host(default: 127.0.0.1)
  --port PORT      port(default: 8200)
  -D, --no-debug   disable the Werkzeug debugger
  -R, --no-reload  do not monitor Python files for changes
```

```
(venv)❯ python app.py
INFO:vilya.models.stubs:SearchClientStub.head is called
INFO:vilya.models.stubs:SearchClientStub.put is called
INFO:vilya.models.stubs:SearchClientStub.head is called
INFO:vilya.models.stubs:SearchClientStub.put is called
INFO:vilya.models.stubs:SearchClientStub.head is called
INFO:vilya.models.stubs:SearchClientStub.put is called
INFO:werkzeug: * Running on http://127.0.0.1:8200/
INFO:werkzeug: * Restarting with reloader
INFO:vilya.models.stubs:SearchClientStub.head is called
INFO:vilya.models.stubs:SearchClientStub.put is called
INFO:vilya.models.stubs:SearchClientStub.head is called
INFO:vilya.models.stubs:SearchClientStub.put is called
INFO:vilya.models.stubs:SearchClientStub.head is called
INFO:vilya.models.stubs:SearchClientStub.put is called
```