### PR TITLE
fix "Invalid US-ASCII character" error

### DIFF
--- a/hub/static/css/mod/compare.scss
+++ b/hub/static/css/mod/compare.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 .compare-range {
     margin-top: -15px;
     float: right;

--- a/hub/static/css/mod/inline-comment-form.scss
+++ b/hub/static/css/mod/inline-comment-form.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @import "css/mod/comment-form-button";
 @import "css/mod/comment-form-content";
 

--- a/hub/static/css/mod/inline-comment.scss
+++ b/hub/static/css/mod/inline-comment.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @import "css/mod/inline-comment-form";
 @import "css/mod/comment-form-preview";
 

--- a/hub/static/css/mod/project-info.scss
+++ b/hub/static/css/mod/project-info.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @import "css/mod/meta-nav";
 @import "css/mod/repository-lang-stats";
 

--- a/hub/static/css/mod/repository-lang-stats.scss
+++ b/hub/static/css/mod/repository-lang-stats.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 .metabox {
   display: inline-block;
   height: 8px;

--- a/hub/static/css/mod/zen-forms.scss
+++ b/hub/static/css/mod/zen-forms.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @import "css/lib/zen-form";
 
 .write-content .enable-fullscreen { position: absolute; top: 5px; right: 16px; color: #333333; opacity: .5; line-height: 1em; }


### PR DESCRIPTION
这些文件里包含了 unicode 字符，在执行 `grunt` 命令时会报 `Invalid US-ASCII character` 错误。