### PR TITLE
fix DOMAIN 配置项的值

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ FAQ
  - `gunicorn -b 127.0.0.1:8001 app:app` # git http daemon
 
 2. vilya.config.DOMAIN
- - if you run 'gunicorn -b IP:PORT app:app', the DOMAIN should be 'http://IP:PORT/'
+ - if you run 'gunicorn -b IP:PORT app:app', the DOMAIN should be 'http://IP:PORT'
 
 
 License

--- a/vilya/config.py
+++ b/vilya/config.py
@@ -54,7 +54,7 @@ BEANSDBCFG = {
     "localhost:7903": range(16),
 }
 
-DOMAIN = 'http://127.0.0.1:8200/'
+DOMAIN = 'http://127.0.0.1:8200'
 IRC_SERVER = 'irc.intra.douban.com'
 IRC_PORT = 12345
 SMTP_SERVER = 'mail.douban.com'


### PR DESCRIPTION
修改前仓库页面生成的地址是： 
`http://127.0.0.1:8200//test/test.git`
修改后的地址是:
`http://127.0.0.1:8200/test/test.git`
代码中其他地方也是类似的用法：
`'%s/%s' % (DOMAIN, url)`
所以需要修改 `DOMAIN` 配置项的值。